### PR TITLE
Prompt to open URL instead of starting the browser with a flag

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -377,9 +377,9 @@ void Agent::WorkerRun() {
                     OnSocketConnection);
   }
   if (err == 0) {
-    printf("Start Chrome Canary with the "
-           "'--remote-debugging-targets=localhost:%d' "
-           "command line option and navigate to 'chrome://inspect'\n", port_);
+    printf("Navigate to chrome-devtools://devtools/remote/serve_file/"
+           "@4604d24a75168768584760ba56d175507941852f/inspector.html?"
+           "&experiments=true&ws=localhost:%d/node\n", port_);
   } else {
     fprintf(stderr, "Unable to open devtools socket: %s\n", uv_strerror(err));
     assert(false);


### PR DESCRIPTION
Instead of telling the user to restart the browser, we should suggest to open a URL that has a proper version of the devtools encoded.
