### PR TITLE
Show error when no inspector is available

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -3418,6 +3418,11 @@ static bool ParseDebugOpt(const char* arg) {
     use_debug_agent = true;
     use_inspector = true;
     port = arg + sizeof("--inspect=") - 1;
+#else
+  } else if (!strncmp(arg, "--inspect", sizeof("--inspect") - 1)) {
+    fprintf(stderr,
+            "Inspector support is not available with this Node.js build\n");
+    return false;
 #endif
   } else {
     return false;


### PR DESCRIPTION
Shows a descriptive error message if --inspect was passed to a Node.js instance built without the Inspector support.
